### PR TITLE
[FEAT] Chip 컴포넌트 추가

### DIFF
--- a/apps/web/src/pages/TestPage.tsx
+++ b/apps/web/src/pages/TestPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@repo/ui';
+import { Button, Chip } from '@repo/ui';
 
 export const TestPage = () => {
   return (
@@ -21,6 +21,7 @@ export const TestPage = () => {
       <Button colorTheme="yellow2" width="376px" height="48px">
         옐로우2
       </Button>
+      <Chip colorTheme="yellow">테스트</Chip>
     </div>
   );
 };

--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+
+type Props = React.ComponentProps<'div'> & ChipProps;
+type ColorTheme = 'yellow' | 'blue';
+
+export interface ChipProps {
+  colorTheme: ColorTheme;
+  width?: string;
+  children: React.ReactNode;
+}
+
+export const Chip = ({ children, colorTheme, width, ...rest }: Props) => {
+  return (
+    <Styled.Container colorTheme={colorTheme} width={width} {...rest}>
+      {children}
+    </Styled.Container>
+  );
+};
+
+const Container = styled.div<ChipProps>`
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+
+  width: ${({ width }) => width || 'auto'};
+  height: 42px;
+  padding: 0 16px;
+  border-radius: 8px;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.13);
+
+  ${({ theme }) => theme.typo.body1m};
+
+  ${({ colorTheme, theme }) => {
+    switch (colorTheme) {
+      case 'yellow':
+        return `
+            color: ${theme.palette.yellow700};
+            background-color: ${theme.palette.yellow50};
+            `;
+      case 'blue':
+        return `
+            color: ${theme.palette.blue700};
+            background-color: ${theme.palette.blue50};
+            `;
+    }
+  }}
+`;
+
+const Styled = { Container };

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,3 +1,4 @@
 import UIProvider from './UIProvider';
 export { UIProvider };
 export { Button } from './Button/Button';
+export { Chip } from './Chip/Chip';


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #9 

## 🪐 작업 내용
- chip 컴포넌트 만들었어요 prop은 colortheme
- 일렉트론 이슈를 해결하려면 오래 걸릴 것 같아 속도가 너무 늦어지면 안되니까 컴포넌트라도 조금씩 만들 예정이에요
- 피그마 보면 이펙트로 shadow랑 popup이 있는데 전역으로 관리하는 것이 더 좋을까 고민중 근데 진짜 적게 쓰임;;

## 🛰️ 바뀐 내용

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 웹 페이지에 노란 테마가 적용된 새로운 Chip 요소가 추가되어 "테스트" 텍스트를 확인할 수 있습니다.
  - UI 라이브러리가 확장되어 다양한 디자인 옵션을 제공하는 Chip 컴포넌트가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->