### PR TITLE
[FEAT] 드롭다운 컴포넌트 추가

### DIFF
--- a/apps/web/src/pages/TestPage.tsx
+++ b/apps/web/src/pages/TestPage.tsx
@@ -1,10 +1,20 @@
 import { useTheme } from '@emotion/react';
 
-import { ButtonTextField, Icon, LoginButton, TextField } from '@repo/ui';
+import {
+  ButtonTextField,
+  Icon,
+  LoginButton,
+  TextField,
+  Dropdown,
+} from '@repo/ui';
 import { Header } from '@web/components/Header';
+import { useState } from 'react';
 
 export const TestPage = () => {
   const theme = useTheme();
+
+  const [selectedContents, setSelectedContents] = useState<string[]>([]);
+  const contents = ['보컬', '기타', '베이스', '키보드', '드럼', '그 외'];
 
   function handleClick(): void {
     console.log('click');
@@ -12,6 +22,39 @@ export const TestPage = () => {
 
   return (
     <div>
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <Icon
+        name="add"
+        fill={theme.palette.yellow700}
+        stroke={theme.palette.yellow700}
+        size={24}
+      />
+      <Dropdown
+        title={'세션 선택'}
+        contents={contents}
+        selectedContents={selectedContents}
+        setSelectedContents={setSelectedContents}
+      />
+      <Dropdown
+        title={'세션 선택'}
+        contents={contents}
+        selectedContents={selectedContents}
+        setSelectedContents={setSelectedContents}
+        width="400px"
+      />
+
       <Icon
         name="add"
         fill={theme.palette.yellow700}
@@ -23,12 +66,10 @@ export const TestPage = () => {
         Google로 3초만에 시작하기
       </LoginButton>
 
-      <LoginButton loginTheme="kakao" iconName="kakao" iconSize={40}>
-        Kakao로 3초만에 시작하기
-      </LoginButton>
       <Icon name="arrowDown" fill={theme.palette.yellow700} size={20} />
       <Icon name="arrowLeft" fill={theme.palette.yellow700} size={32} />
       <Icon name="google" size={40} />
+
       <Icon name="kakao" size={40} />
 
       <TextField width="312px" placeholder="테스트1" />
@@ -42,6 +83,9 @@ export const TestPage = () => {
         warning={false}
         placeholder="테스트테스트"
       />
+      <LoginButton loginTheme="kakao" iconName="kakao" iconSize={40}>
+        Kakao로 3초만에 시작하기
+      </LoginButton>
     </div>
   );
 };

--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState } from 'react';
+import styled from '@emotion/styled';
+import { Icon } from '../Icon/Icon';
+
+interface DropdownProps {
+  title: string;
+  contents: string[];
+  selectedContents: string[];
+  setSelectedContents: (selected: string[]) => void;
+  width?: string;
+}
+
+export const Dropdown = ({
+  title,
+  contents,
+  selectedContents,
+  setSelectedContents,
+  width = '312px',
+}: DropdownProps) => {
+  const [open, setOpen] = useState<boolean>(false);
+  const selectContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const oustideClickHandler = (e: MouseEvent) => {
+      if (
+        selectContainerRef.current &&
+        !selectContainerRef.current.contains(e.target as HTMLElement)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', oustideClickHandler);
+
+    return () => {
+      document.removeEventListener('click', oustideClickHandler);
+    };
+  }, []);
+
+  return (
+    <Dropdowns ref={selectContainerRef} width={width}>
+      <DropdownContent onClick={() => setOpen((prev) => !prev)}>
+        <DropdownLabel>
+          <span>{title}</span>
+        </DropdownLabel>
+        <DropdownSelected>
+          {selectedContents.length === 0 ? (
+            <span className="no-filter"> </span>
+          ) : (
+            <span className="selected">
+              {`${selectedContents[0]}${selectedContents.length > 1 ? ` 외 ${selectedContents.length - 1}` : ''}`}
+            </span>
+          )}
+          {open ? (
+            <Icon name="arrowDown" size={20} />
+          ) : (
+            <Icon name="arrowUp" size={20} />
+          )}
+        </DropdownSelected>
+      </DropdownContent>
+      {open && (
+        <DropdownExpandContent>
+          {contents.map((content) => (
+            <div
+              key={content}
+              className="content"
+              onClick={() => {
+                if (!selectedContents.includes(content))
+                  setSelectedContents([...selectedContents, content]);
+              }}
+            >
+              {content}
+            </div>
+          ))}
+        </DropdownExpandContent>
+      )}
+    </Dropdowns>
+  );
+};
+
+const Dropdowns = styled.div<{ width: string }>`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  gap: 12px;
+  width: ${({ width }) => width};
+`;
+
+const DropdownContent = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  gap: 20px;
+  padding: 0 16px;
+  height: 48px;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.palette.gray200};
+
+  background: ${({ theme }) => theme.palette.white};
+  cursor: pointer;
+`;
+
+const DropdownLabel = styled.div`
+  display: flex;
+  gap: 10px;
+
+  ${({ theme }) => theme.typo.body1m};
+
+  .filter-title {
+    color: ${({ theme }) => theme.palette.gray700};
+  }
+`;
+
+const DropdownSelected = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  ${({ theme }) => theme.typo.body1m};
+
+  .no-filter {
+    color: ${({ theme }) => theme.palette.gray300};
+  }
+  .selected {
+    color: ${({ theme }) => theme.palette.yellow500};
+  }
+`;
+
+const DropdownExpandContent = styled.div`
+  position: absolute;
+  top: 62px;
+  left: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+
+  background: ${({ theme }) => theme.palette.white};
+  border: 1px solid ${({ theme }) => theme.palette.gray200};
+
+  overflow: hidden;
+  width: 100%;
+  border-radius: 8px;
+
+  .content {
+    padding: 12px 24px;
+    height: 48px;
+    align-items: center;
+    ${({ theme }) => theme.typo.body1m};
+    color: ${({ theme }) => theme.palette.gray800};
+    background-color: ${({ theme }) => theme.palette.white};
+
+    &:hover {
+      background-color: ${({ theme }) => theme.palette.gray100};
+    }
+  }
+`;

--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { Icon } from '../Icon/Icon';
+import { useTheme } from '@emotion/react';
 
 interface DropdownProps {
   title: string;
@@ -17,59 +18,67 @@ export const Dropdown = ({
   setSelectedContents,
   width = '312px',
 }: DropdownProps) => {
-  const [open, setOpen] = useState<boolean>(false);
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
   const selectContainerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const oustideClickHandler = (e: MouseEvent) => {
-      if (
-        selectContainerRef.current &&
-        !selectContainerRef.current.contains(e.target as HTMLElement)
-      ) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('click', oustideClickHandler);
+  const oustideClickHandler = (e: MouseEvent) => {
+    if (
+      selectContainerRef.current &&
+      !selectContainerRef.current.contains(e.target as HTMLElement)
+    ) {
+      setOpen(false);
+    }
+  };
 
-    return () => {
-      document.removeEventListener('click', oustideClickHandler);
-    };
+  useEffect(() => {
+    document.addEventListener('click', oustideClickHandler);
+    return () => document.removeEventListener('click', oustideClickHandler);
   }, []);
+
+  const handleToggleDropdown = () => setOpen((prev) => !prev);
+
+  const handleSelectContent = (content: string) => {
+    setSelectedContents([
+      ...(selectedContents.includes(content)
+        ? selectedContents.filter((item) => item !== content)
+        : [...selectedContents, content]),
+    ]);
+  };
 
   return (
     <Dropdowns ref={selectContainerRef} width={width}>
-      <DropdownContent onClick={() => setOpen((prev) => !prev)}>
-        <DropdownLabel>
-          <span>{title}</span>
-        </DropdownLabel>
+      <DropdownHeader onClick={handleToggleDropdown}>
+        <DropdownLabel>{title}</DropdownLabel>
         <DropdownSelected>
           {selectedContents.length === 0 ? (
             <span className="no-filter"> </span>
           ) : (
             <span className="selected">
-              {`${selectedContents[0]}${selectedContents.length > 1 ? ` 외 ${selectedContents.length - 1}` : ''}`}
+              {`${selectedContents[0]}${
+                selectedContents.length > 1
+                  ? ` 외 ${selectedContents.length - 1}`
+                  : ''
+              }`}
             </span>
           )}
-          {open ? (
-            <Icon name="arrowDown" size={20} />
-          ) : (
-            <Icon name="arrowUp" size={20} />
-          )}
+          <Icon
+            name={open ? 'arrowDown' : 'arrowUp'}
+            fill={theme.palette.yellow500}
+            size={24}
+          />
         </DropdownSelected>
-      </DropdownContent>
+      </DropdownHeader>
       {open && (
         <DropdownExpandContent>
           {contents.map((content) => (
-            <div
+            <DropdownItem
               key={content}
-              className="content"
-              onClick={() => {
-                if (!selectedContents.includes(content))
-                  setSelectedContents([...selectedContents, content]);
-              }}
+              onClick={() => handleSelectContent(content)}
+              selected={selectedContents.includes(content)}
             >
               {content}
-            </div>
+            </DropdownItem>
           ))}
         </DropdownExpandContent>
       )}
@@ -85,37 +94,28 @@ const Dropdowns = styled.div<{ width: string }>`
   width: ${({ width }) => width};
 `;
 
-const DropdownContent = styled.div`
+const DropdownHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-
   gap: 20px;
   padding: 0 16px;
   height: 48px;
   border-radius: 8px;
   border: 1px solid ${({ theme }) => theme.palette.gray200};
-
   background: ${({ theme }) => theme.palette.white};
   cursor: pointer;
 `;
 
-const DropdownLabel = styled.div`
-  display: flex;
-  gap: 10px;
-
+const DropdownLabel = styled.span`
   ${({ theme }) => theme.typo.body1m};
-
-  .filter-title {
-    color: ${({ theme }) => theme.palette.gray700};
-  }
+  color: ${({ theme }) => theme.palette.gray700};
 `;
 
 const DropdownSelected = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
-
   ${({ theme }) => theme.typo.body1m};
 
   .no-filter {
@@ -133,24 +133,25 @@ const DropdownExpandContent = styled.div`
   z-index: 2;
   display: flex;
   flex-direction: column;
-
   background: ${({ theme }) => theme.palette.white};
   border: 1px solid ${({ theme }) => theme.palette.gray200};
-
-  overflow: hidden;
   width: 100%;
   border-radius: 8px;
+  overflow: hidden;
+`;
 
-  .content {
-    padding: 12px 24px;
-    height: 48px;
-    align-items: center;
-    ${({ theme }) => theme.typo.body1m};
-    color: ${({ theme }) => theme.palette.gray800};
-    background-color: ${({ theme }) => theme.palette.white};
+const DropdownItem = styled.button<{ selected: boolean }>`
+  padding: 12px 24px;
+  height: 48px;
+  text-align: left;
+  ${({ theme }) => theme.typo.body1m};
+  color: ${({ selected, theme }) =>
+    selected ? theme.palette.yellow500 : theme.palette.gray800};
+  background-color: ${({ theme }) => theme.palette.white};
+  border: none;
+  cursor: pointer;
 
-    &:hover {
-      background-color: ${({ theme }) => theme.palette.gray100};
-    }
+  &:hover {
+    background-color: ${({ theme }) => theme.palette.gray100};
   }
 `;

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -6,3 +6,4 @@ export { Chip } from './Chip/Chip';
 export { TextField } from './TextField/TextField';
 export { ButtonTextField } from './TextField/ButtonTextField';
 export { LoginButton } from './Button/LoginButton';
+export { Dropdown } from './Dropdown/Dropdown';


### PR DESCRIPTION
## #️⃣연관된 이슈

#9

## 🪐 작업 내용
드롭다운 컴포넌트 만들었어요

## 🛰️ 바뀐 내용

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 테스트 페이지에 '세션 선택' 드롭다운 메뉴를 추가하여 사용자가 세션 항목을 쉽게 선택할 수 있습니다.
	- 드롭다운은 선택/해제 및 외부 클릭 시 자동 닫힘 기능을 제공합니다.
	- 카카오 로그인 버튼이 페이지 하단에 다시 추가되어 로그인 옵션이 복원되었습니다.
	- 또한, 새 드롭다운 컴포넌트가 UI 라이브러리에 포함되어 다양한 화면에서 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->