### PR TITLE
[FEAT] roomid로 접속 및 세션 관리 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy mediasoup to EC2
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - feat/ci-cd
+    paths:
+      - 'apps/server/**'
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/server/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Copy server files to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_KEY }}
+          source: apps/server/**
+          target: /home/ubuntu/apps/server/
+          strip_components: 2
+
+      - name: SSH and build/start server
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd /home/ubuntu/apps/server
+            npm install --legacy-peer-deps
+            npm run build
+            pm2 restart mediasoup || pm2 start dist/index.js --name mediasoup --interpreter node --interpreter-args="--input-type=module"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+
+
+.idea

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,10 +1,11 @@
 {
   "name": "server",
   "version": "0.0.0",
+  "type": "module",
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc",
+    "build": "tsc && tsc-alias",
     "start": "node dist/index.js"
   },
   "dependencies": {
@@ -17,6 +18,8 @@
     "ws": "^8.18.1"
   },
   "devDependencies": {
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "tsc-alias": "^1.8.16",
+    "tsconfig-paths": "^3.12.0"
   }
 }

--- a/apps/server/src/handlers/handleConnectRecvTransport.ts
+++ b/apps/server/src/handlers/handleConnectRecvTransport.ts
@@ -1,17 +1,21 @@
-import { transportManager } from '@server/managers/TransportManager';
 import type { WebSocket as WsSocket } from 'ws';
 import type { DtlsParameters } from 'mediasoup/node/lib/types';
+import { roomManager } from '@server/managers/RoomManager';
 
 interface ExtendedWebSocket extends WsSocket {
   userId?: string;
+  roomId?: string;
 }
 
 export async function handleConnectRecvTransport(
   ws: ExtendedWebSocket,
   dtlsParameters: DtlsParameters
 ) {
-  const userId = ws.userId;
-  const transport = transportManager.get(userId);
+  const room = roomManager.get(ws.roomId);
+  if (!room || !ws.userId) return;
+
+  const transport = room.transportManager.get(ws.userId);
   if (!transport) return;
+
   await transport.connect({ dtlsParameters });
 }

--- a/apps/server/src/handlers/handleConnectTransport.ts
+++ b/apps/server/src/handlers/handleConnectTransport.ts
@@ -1,17 +1,21 @@
-import { transportManager } from '@server/managers/TransportManager';
 import type { WebSocket as WsSocket } from 'ws';
 import type { DtlsParameters } from 'mediasoup/node/lib/types';
+import { roomManager } from '@server/managers/RoomManager';
 
 interface ExtendedWebSocket extends WsSocket {
   userId?: string;
+  roomId?: string;
 }
 
 export async function handleConnectTransport(
   ws: ExtendedWebSocket,
   dtlsParameters: DtlsParameters
 ) {
-  const userId = ws.userId;
-  const transport = transportManager.get(userId);
+  const room = roomManager.get(ws.roomId);
+  if (!room || !ws.userId) return;
+
+  const transport = room.transportManager.get(ws.userId);
   if (!transport) return;
+
   await transport.connect({ dtlsParameters });
 }

--- a/apps/server/src/handlers/handleCreateRecvTransport.ts
+++ b/apps/server/src/handlers/handleCreateRecvTransport.ts
@@ -1,18 +1,22 @@
 import { mediasoupConfig } from '@server/config/mediasoupConfig';
-import { transportManager } from '@server/managers/TransportManager';
-import { router } from '@server/mediasoup';
+import { roomManager } from '@server/managers/RoomManager';
+
 import type { WebSocket as WsSocket } from 'ws';
 
 interface ExtendedWebSocket extends WsSocket {
   userId?: string;
+  roomId?: string;
 }
 
 export async function handleCreateRecvTransport(ws: ExtendedWebSocket) {
-  const transport = await router.createWebRtcTransport(
+  const room = roomManager.get(ws.roomId);
+  if (!room || !ws.userId) return;
+
+  const transport = await room.router.createWebRtcTransport(
     mediasoupConfig.webRtcTransport
   );
-  const userId = ws.userId;
-  transportManager.set(userId, transport);
+
+  room.transportManager.set(ws.userId, transport);
 
   ws.send(
     JSON.stringify({

--- a/apps/server/src/handlers/handleCreateTransport.ts
+++ b/apps/server/src/handlers/handleCreateTransport.ts
@@ -1,18 +1,21 @@
 import { mediasoupConfig } from '@server/config/mediasoupConfig';
-import { transportManager } from '@server/managers/TransportManager';
-import { router } from '@server/mediasoup';
+import { roomManager } from '@server/managers/RoomManager';
 import type { WebSocket as WsSocket } from 'ws';
 
 interface ExtendedWebSocket extends WsSocket {
   userId?: string;
+  roomId?: string;
 }
 
 export async function handleCreateTransport(ws: ExtendedWebSocket) {
-  const transport = await router.createWebRtcTransport(
+  const room = roomManager.get(ws.roomId);
+  if (!room || !ws.userId) return;
+
+  const transport = await room.router.createWebRtcTransport(
     mediasoupConfig.webRtcTransport
   );
-  const userId = ws.userId;
-  transportManager.set(userId, transport);
+
+  room.transportManager.set(ws.userId, transport);
 
   ws.send(
     JSON.stringify({

--- a/apps/server/src/handlers/handleDisconnect.ts
+++ b/apps/server/src/handlers/handleDisconnect.ts
@@ -1,17 +1,16 @@
-import { peerManager } from '@server/managers/PeerManager';
-import { transportManager } from '@server/managers/TransportManager';
-
+import { roomManager } from '@server/managers/RoomManager';
 import { WebSocket as WsSocket } from 'ws';
 
 interface ExtendedWebSocket extends WsSocket {
   userId?: string;
+  roomId?: string;
 }
 
 export function handleDisconnect(ws: ExtendedWebSocket) {
-  const userId = ws.userId;
-  if (!userId) return;
+  const room = roomManager.get(ws.roomId);
+  if (!room || !ws.userId) return;
 
-  transportManager.delete(userId);
-  peerManager.remove(userId);
-  //TODO producer 관련 처리
+  room.transportManager.delete(ws.userId);
+  room.peerManager.remove(ws.userId);
+  room.producerManager.delete(ws.userId);
 }

--- a/apps/server/src/handlers/handleJoin.ts
+++ b/apps/server/src/handlers/handleJoin.ts
@@ -1,22 +1,33 @@
-import { peerManager } from '@server/managers/PeerManager';
 import type { WebSocket as WsSocket } from 'ws';
+import { roomManager } from '@server/managers/RoomManager';
 
 interface ExtendedWebSocket extends WsSocket {
   userId?: string;
+  roomId?: string;
 }
 
-export function handleJoin(
+export async function handleJoin(
   ws: ExtendedWebSocket,
-  userInfo: { id: string; name: string; role: string }
+  data: {
+    roomId: string;
+    userInfo: { id: string; name: string; role: string };
+  }
 ) {
+  const { roomId, userInfo } = data;
+
   ws.userId = userInfo.id;
-  peerManager.add(userInfo.id, {
+  ws.roomId = roomId;
+
+  const room = await roomManager.getOrCreate(roomId);
+
+  room.peerManager.add(userInfo.id, {
     ws,
     name: userInfo.name,
     role: userInfo.role,
   });
 
-  const summary = peerManager.getAllSummaries();
-  peerManager.broadcast('peerList', summary);
-  console.log('[peerManager]', peerManager.getAllSummaries());
+  const summary = room.peerManager.getAllSummaries();
+  room.peerManager.broadcast('peerList', summary);
+
+  console.log(`[peerManager][${roomId}]`, summary);
 }

--- a/apps/server/src/handlers/handleMessage.ts
+++ b/apps/server/src/handlers/handleMessage.ts
@@ -12,7 +12,7 @@ import type { WebSocket as WsSocket } from 'ws';
 export async function handleMessage(ws: WsSocket, data: Message) {
   switch (data.type) {
     case 'join':
-      return handleJoin(ws, data.userInfo);
+      return handleJoin(ws, data);
     case 'getRouterRtpCapabilities':
       return handleGetRouterRtpCapabilities(ws);
     case 'createTransport':

--- a/apps/server/src/managers/PeerManager.ts
+++ b/apps/server/src/managers/PeerManager.ts
@@ -2,7 +2,7 @@ import type { WebSocket as WsSocket } from 'ws';
 
 type Peer = { ws: WsSocket; name: string; role: string };
 
-class PeerManager {
+export class PeerManager {
   private peers = new Map<string, Peer>();
 
   add(id: string, peer: Peer) {
@@ -26,6 +26,8 @@ class PeerManager {
       peer.ws.send(JSON.stringify({ type, data }));
     }
   }
-}
 
-export const peerManager = new PeerManager();
+  get entries() {
+    return this.peers.entries();
+  }
+}

--- a/apps/server/src/managers/ProducerManager.ts
+++ b/apps/server/src/managers/ProducerManager.ts
@@ -1,18 +1,21 @@
 import type { Producer } from 'mediasoup/node/lib/types';
 
-const producers = new Map<string, Producer>();
+export class ProducerManager {
+  private producers = new Map<string, Producer>();
 
-export const producerManager = {
-  set: (userId: string, producer: Producer) => {
-    producers.set(userId, producer);
-  },
-  get: (userId: string) => {
-    return producers.get(userId);
-  },
-  getAll: () => {
-    return Array.from(producers.entries());
-  },
-  delete: (userId: string) => {
-    producers.delete(userId);
-  },
-};
+  set(userId: string, producer: Producer) {
+    this.producers.set(userId, producer);
+  }
+
+  get(userId: string) {
+    return this.producers.get(userId);
+  }
+
+  getAll() {
+    return Array.from(this.producers.entries());
+  }
+
+  delete(userId: string) {
+    this.producers.delete(userId);
+  }
+}

--- a/apps/server/src/managers/RoomManager.ts
+++ b/apps/server/src/managers/RoomManager.ts
@@ -1,0 +1,58 @@
+import * as mediasoup from 'mediasoup';
+import { mediasoupConfig } from '@server/config/mediasoupConfig';
+import { PeerManager } from './PeerManager';
+import { ProducerManager } from './ProducerManager';
+import { TransportManager } from './TransportManager';
+
+type Room = {
+  router: mediasoup.types.Router;
+  peerManager: PeerManager;
+  producerManager: ProducerManager;
+  transportManager: TransportManager;
+};
+
+class RoomManager {
+  private rooms = new Map<string, Room>();
+
+  async getOrCreate(roomId: string): Promise<Room> {
+    if (!this.rooms.has(roomId)) {
+      const worker = await mediasoup.createWorker(mediasoupConfig.worker);
+      const router = await worker.createRouter({
+        mediaCodecs: [
+          {
+            kind: 'audio',
+            mimeType: 'audio/opus',
+            clockRate: 48000,
+            channels: 2,
+          },
+        ],
+      });
+
+      const room: Room = {
+        router,
+        peerManager: new PeerManager(),
+        producerManager: new ProducerManager(),
+        transportManager: new TransportManager(),
+      };
+
+      this.rooms.set(roomId, room);
+      console.log(`Room "${roomId}" 생성됨`);
+    }
+
+    return this.rooms.get(roomId)!;
+  }
+
+  get(roomId: string): Room | undefined {
+    return this.rooms.get(roomId);
+  }
+
+  delete(roomId: string) {
+    this.rooms.delete(roomId);
+  }
+
+  getAllRoomIds(): string[] {
+    return [...this.rooms.keys()];
+  }
+}
+
+export const roomManager = new RoomManager();

--- a/apps/server/src/managers/TransportManager.ts
+++ b/apps/server/src/managers/TransportManager.ts
@@ -1,9 +1,9 @@
-import mediasoup from 'mediasoup';
+import type { WebRtcTransport } from 'mediasoup/node/lib/types';
 
-class TransportManager {
-  private map = new Map<string, mediasoup.types.WebRtcTransport>();
+export class TransportManager {
+  private map = new Map<string, WebRtcTransport>();
 
-  set(userId: string, transport: mediasoup.types.WebRtcTransport) {
+  set(userId: string, transport: WebRtcTransport) {
     this.map.set(userId, transport);
   }
 
@@ -15,5 +15,3 @@ class TransportManager {
     this.map.delete(userId);
   }
 }
-
-export const transportManager = new TransportManager();

--- a/apps/server/src/types/messages.ts
+++ b/apps/server/src/types/messages.ts
@@ -6,19 +6,27 @@ import type {
 } from 'mediasoup/node/lib/types';
 
 export type Message =
-  | { type: 'join'; userInfo: { id: string; name: string; role: string } }
-  | { type: 'getRouterRtpCapabilities'; userId: string }
-  | { type: 'createTransport'; userId: string }
-  | { type: 'connectTransport'; userId: string; dtlsParameters: DtlsParameters }
+  | {
+      type: 'join';
+      roomId: string;
+      userInfo: { id: string; name: string; role: string };
+    }
+  | { type: 'getRouterRtpCapabilities' }
+  | { type: 'createTransport' }
+  | { type: 'connectTransport'; dtlsParameters: DtlsParameters }
   | {
       type: 'produce';
-      userId: string;
       kind: MediaKind;
       rtpParameters: RtpParameters;
     }
   | {
+      type: 'createRecvTransport';
+    }
+  | {
       type: 'connectRecvTransport';
-      userId: string;
       dtlsParameters: DtlsParameters;
     }
-  | { type: 'consume'; userId: string; rtpCapabilities: RtpCapabilities };
+  | {
+      type: 'consume';
+      rtpCapabilities: RtpCapabilities;
+    };

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
+    "outDir": "dist",
     "paths": {
-      "@server/*": ["./src/*"]
+      "@server/*": ["./src/*", "./mediasoup/*"]
     },
     "baseUrl": ".",
     "allowJs": true,

--- a/apps/web/src/pages/TestPage.tsx
+++ b/apps/web/src/pages/TestPage.tsx
@@ -1,4 +1,4 @@
-import { RoomCard, SessionCard } from '@repo/ui';
+import { RoomCard, SessionCard, Tab } from '@repo/ui';
 import { startWebRTC } from '@web/webrtc';
 import { useRef, useState } from 'react';
 
@@ -64,6 +64,7 @@ export const TestPage = () => {
   };
 
   const [liked, setLiked] = useState(false);
+  const [activeTab, setActiveTab] = useState<'search' | 'liked'>('search');
 
   return (
     <div style={{ padding: '20px' }}>
@@ -90,6 +91,18 @@ export const TestPage = () => {
         isLiked={liked}
         onLike={() => setLiked(!liked)}
       />
+      <Tab<'search' | 'liked'>
+        items={[
+          { label: '세션 검색', value: 'search' },
+          { label: '세션 찜 리스트 보기', value: 'liked' },
+        ]}
+        selected={activeTab}
+        onChange={setActiveTab}
+      />
+
+      {activeTab === 'search' && <div>세션 검색</div>}
+      {activeTab === 'liked' && <div>세션 찜 리스트 보기</div>}
+
       <h3>참가자 목록</h3>
       <div
         style={{

--- a/apps/web/src/pages/TestPage.tsx
+++ b/apps/web/src/pages/TestPage.tsx
@@ -1,3 +1,4 @@
+import { SessionCard } from '@repo/ui';
 import { startWebRTC } from '@web/webrtc';
 import { useRef, useState } from 'react';
 
@@ -69,6 +70,16 @@ export const TestPage = () => {
       <button onClick={handleStartWebRTC} disabled={started}>
         연결 시작
       </button>
+
+      <SessionCard
+        imageUrl="https://i.esdrop.com/d/f/AfOYjCl4ON/sZfPFcWjDG.jpg"
+        userName="유지예"
+        userDescription="자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 "
+        tags={['Vocal', 'Guitar']}
+        onLike={() => {
+          console.log('좋아요 버튼 눌림');
+        }}
+      />
 
       <h3>참가자 목록</h3>
       <div

--- a/apps/web/src/pages/TestPage.tsx
+++ b/apps/web/src/pages/TestPage.tsx
@@ -1,4 +1,4 @@
-import { SessionCard } from '@repo/ui';
+import { RoomCard, SessionCard } from '@repo/ui';
 import { startWebRTC } from '@web/webrtc';
 import { useRef, useState } from 'react';
 
@@ -63,6 +63,8 @@ export const TestPage = () => {
     setStarted(true);
   };
 
+  const [liked, setLiked] = useState(false);
+
   return (
     <div style={{ padding: '20px' }}>
       <h2>합주 테스트 페이지</h2>
@@ -76,11 +78,18 @@ export const TestPage = () => {
         userName="유지예"
         userDescription="자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 자기 소개 들어가는 자리 "
         tags={['Vocal', 'Guitar']}
-        onLike={() => {
-          console.log('좋아요 버튼 눌림');
-        }}
+        isLiked={liked}
+        onLike={() => setLiked(!liked)}
       />
 
+      <RoomCard
+        imageUrl="https://i.esdrop.com/d/f/AfOYjCl4ON/XN5oxZTwMD.png"
+        genre="락"
+        remainingSessions={['보컬', '기타']}
+        roomName="합주실이름티비"
+        isLiked={liked}
+        onLike={() => setLiked(!liked)}
+      />
       <h3>참가자 목록</h3>
       <div
         style={{

--- a/apps/web/src/pages/TestPage.tsx
+++ b/apps/web/src/pages/TestPage.tsx
@@ -1,4 +1,4 @@
-import { RoomCard, SessionCard, Tab } from '@repo/ui';
+import { ChatCard, RoomCard, SessionCard, Tab } from '@repo/ui';
 import { startWebRTC } from '@web/webrtc';
 import { useRef, useState } from 'react';
 
@@ -73,6 +73,17 @@ export const TestPage = () => {
       <button onClick={handleStartWebRTC} disabled={started}>
         연결 시작
       </button>
+
+      <ChatCard
+        targetprofileImgUrl="https://i.esdrop.com/d/f/AfOYjCl4ON/sZfPFcWjDG.jpg"
+        targetnickname="닉네임"
+        lastMessage="마지막 채팅 내용 들어가는 자리 마지막 채팅 내용 들어가는 자리 마지막 채팅 내용 들어가는 자리 마지막 채팅 내용 들어가는 자리"
+        lastMessageTime="2025.05.06"
+        unreadCount={3}
+        onClick={() => {
+          console.log('클릭티비');
+        }}
+      />
 
       <SessionCard
         imageUrl="https://i.esdrop.com/d/f/AfOYjCl4ON/sZfPFcWjDG.jpg"

--- a/packages/ui/src/components/Card/RoomCard.tsx
+++ b/packages/ui/src/components/Card/RoomCard.tsx
@@ -1,0 +1,107 @@
+import styled from '@emotion/styled';
+import { useTheme } from '@emotion/react';
+import { Chip } from '../Chip/Chip';
+import { Icon } from '../Icon/Icon';
+
+export type RoomCardProps = React.ComponentProps<'div'> & {
+  imageUrl: string;
+  genre: string;
+  remainingSessions: string[];
+  roomName: string;
+  isLiked: boolean;
+  onLike: () => void;
+};
+
+export const RoomCard = ({
+  imageUrl,
+  genre,
+  remainingSessions,
+  roomName,
+  isLiked,
+  onLike,
+}: RoomCardProps) => {
+  const theme = useTheme();
+
+  return (
+    <CardContainer>
+      <ImageContainer imageUrl={imageUrl}>
+        <LikeButton onClick={onLike}>
+          <Icon
+            name="heart"
+            size={24}
+            fill={isLiked ? theme.palette.yellow500 : theme.palette.white}
+          />
+        </LikeButton>
+        <RoomName>
+          <Chip colorTheme={'yellow'}>{roomName}</Chip>
+        </RoomName>
+      </ImageContainer>
+      <RoomInfo>
+        <div>
+          <span className="label">장르: </span>
+          <span className="text">{genre}</span>
+        </div>
+        <div>
+          <span className="label">잔여 세션: </span>
+          <span className="text">{remainingSessions.join(', ')}</span>
+        </div>
+      </RoomInfo>
+    </CardContainer>
+  );
+};
+
+const CardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 270px;
+  height: 254px;
+`;
+const ImageContainer = styled.div<{ imageUrl: string }>`
+  position: relative;
+  width: 100%;
+  height: 154px;
+  overflow: hidden;
+  border-radius: 16px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  background-image: url(${({ imageUrl }) => imageUrl});
+`;
+
+const LikeButton = styled.button`
+  position: absolute;
+  top: 24px;
+  right: 20px;
+
+  cursor: pointer;
+  z-index: 1;
+`;
+
+const RoomName = styled.div`
+  position: absolute;
+  bottom: 12px;
+  right: 20px;
+  display: flex;
+  gap: 12px;
+`;
+
+const RoomInfo = styled.div`
+  padding-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  span {
+    ${({ theme }) => theme.typo.body2m};
+  }
+
+  .label {
+    color: ${({ theme }) => theme.palette.yellow800};
+  }
+
+  .text {
+    color: ${({ theme }) => theme.palette.gray900};
+  }
+`;

--- a/packages/ui/src/components/Card/SessionCard.tsx
+++ b/packages/ui/src/components/Card/SessionCard.tsx
@@ -1,0 +1,126 @@
+import styled from '@emotion/styled';
+import { useTheme } from '@emotion/react';
+import { Chip } from '../Chip/Chip';
+import { Icon } from '../Icon/Icon';
+import { useState } from 'react';
+
+export type SessionCardProps = React.ComponentProps<'div'> & {
+  imageUrl: string;
+  userName: string;
+  userDescription: string;
+  tags: string[];
+  onLike: () => void;
+};
+
+export const SessionCard = ({
+  imageUrl,
+  userName,
+  userDescription,
+  tags,
+  onLike,
+}: SessionCardProps) => {
+  const theme = useTheme();
+  const [isLiked, setIsLiked] = useState(false);
+
+  const handleLikeClick = () => {
+    setIsLiked(!isLiked);
+    onLike();
+  };
+  return (
+    <CardContainer>
+      <ImageContainer>
+        <ProfileImage src={imageUrl} alt="profile" />
+
+        <LikeButton onClick={handleLikeClick}>
+          <Icon
+            name="heart"
+            size={24}
+            fill={isLiked ? theme.palette.yellow500 : theme.palette.white}
+          />
+        </LikeButton>
+        <TagList>
+          {tags.map((tag) => (
+            <Chip key={tag} colorTheme={'yellow'}>
+              {tag}
+            </Chip>
+          ))}
+        </TagList>
+      </ImageContainer>
+      <UserInfo>
+        <UserName>{userName}</UserName>
+        <UserDescription>{userDescription}</UserDescription>
+      </UserInfo>
+    </CardContainer>
+  );
+};
+
+const CardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 270px;
+  height: 315px;
+  border-radius: 16px;
+  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.13);
+`;
+
+const ImageContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 203px;
+  overflow: hidden;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+
+const ProfileImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const LikeButton = styled.button`
+  position: absolute;
+  top: 24px;
+  right: 20px;
+
+  cursor: pointer;
+  z-index: 1;
+`;
+
+const TagList = styled.div`
+  position: absolute;
+  bottom: 12px;
+  right: 20px;
+  display: flex;
+  gap: 12px;
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 20px;
+  gap: 4px;
+`;
+
+const UserName = styled.div`
+  ${({ theme }) => theme.typo.body1m};
+  color: ${({ theme }) => theme.palette.yellow800};
+`;
+
+const UserDescription = styled.div`
+  ${({ theme }) => theme.typo.label1r};
+  color: ${({ theme }) => theme.palette.gray900};
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: keep-all;
+`;

--- a/packages/ui/src/components/Card/SessionCard.tsx
+++ b/packages/ui/src/components/Card/SessionCard.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 import { Chip } from '../Chip/Chip';
 import { Icon } from '../Icon/Icon';
-import { useState } from 'react';
 
 export type SessionCardProps = React.ComponentProps<'div'> & {
   imageUrl: string;
   userName: string;
   userDescription: string;
   tags: string[];
+  isLiked: boolean;
   onLike: () => void;
 };
 
@@ -17,21 +17,16 @@ export const SessionCard = ({
   userName,
   userDescription,
   tags,
+  isLiked,
   onLike,
 }: SessionCardProps) => {
   const theme = useTheme();
-  const [isLiked, setIsLiked] = useState(false);
 
-  const handleLikeClick = () => {
-    setIsLiked(!isLiked);
-    onLike();
-  };
   return (
     <CardContainer>
       <ImageContainer>
         <ProfileImage src={imageUrl} alt="profile" />
-
-        <LikeButton onClick={handleLikeClick}>
+        <LikeButton onClick={onLike}>
           <Icon
             name="heart"
             size={24}

--- a/packages/ui/src/components/Chat/ChatCard.tsx
+++ b/packages/ui/src/components/Chat/ChatCard.tsx
@@ -1,0 +1,99 @@
+import styled from '@emotion/styled';
+
+export type ChatCardProps = React.ComponentProps<'div'> & {
+  targetprofileImgUrl: string;
+  targetnickname: string;
+  lastMessage: string;
+  lastMessageTime: string;
+  unreadCount: number;
+  onClick: () => void;
+};
+
+export const ChatCard = ({
+  targetprofileImgUrl,
+  targetnickname,
+  lastMessage,
+  lastMessageTime,
+  unreadCount,
+
+  onClick,
+}: ChatCardProps) => {
+  return (
+    <CardContainer onClick={onClick}>
+      <ImageContainer>
+        <ProfileImage targetprofileImgUrl={targetprofileImgUrl} />
+      </ImageContainer>
+      <UserInfo>
+        <TopLine>
+          <UserName>{targetnickname}</UserName>
+          {unreadCount > 0 && <UnreadCount>{unreadCount}</UnreadCount>}
+        </TopLine>
+        <LastMessage>{lastMessage}</LastMessage>
+        <LastMessageTime>{lastMessageTime}</LastMessageTime>
+      </UserInfo>
+    </CardContainer>
+  );
+};
+
+const CardContainer = styled.div`
+  display: flex;
+  width: 300px;
+  align-items: center;
+
+  border-radius: 8px;
+  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.13);
+`;
+
+const ImageContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0px 12px;
+`;
+const ProfileImage = styled.div<{ targetprofileImgUrl: string }>`
+  width: 68px;
+  height: 68px;
+  border-radius: 50px;
+  background-image: url(${({ targetprofileImgUrl }) => targetprofileImgUrl});
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  width: 100%;
+  padding: 12px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 4px;
+`;
+
+const TopLine = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const UserName = styled.div`
+  ${({ theme }) => theme.typo.body2m};
+  color: ${({ theme }) => theme.palette.gray900};
+`;
+const UnreadCount = styled.div`
+  ${({ theme }) => theme.typo.body2m};
+  color: ${({ theme }) => theme.palette.yellow700};
+`;
+const LastMessage = styled.div`
+  ${({ theme }) => theme.typo.label1r};
+  color: ${({ theme }) => theme.palette.gray900};
+
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: keep-all;
+`;
+const LastMessageTime = styled.div`
+  ${({ theme }) => theme.typo.label2};
+  color: ${({ theme }) => theme.palette.gray500};
+`;

--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -23,7 +23,7 @@ const Container = styled.div<ChipProps>`
   white-space: nowrap;
 
   width: ${({ width }) => width || 'auto'};
-  height: 42px;
+  height: 38px;
   padding: 0 16px;
   border-radius: 8px;
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.13);

--- a/packages/ui/src/components/Tab/Tab.tsx
+++ b/packages/ui/src/components/Tab/Tab.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+export type TabItem = {
+  label: string;
+  value: string;
+};
+
+type TabProps<T extends string> = {
+  items: { label: string; value: T }[];
+  selected: T;
+  onChange: (value: T) => void;
+};
+
+export const Tab = <T extends string>({
+  items,
+  selected,
+  onChange,
+}: TabProps<T>) => {
+  return (
+    <TabWrapper>
+      {items.map(({ label, value }) => (
+        <TabButton
+          key={value}
+          isActive={value === selected}
+          onClick={() => onChange(value)}
+        >
+          {label}
+        </TabButton>
+      ))}
+    </TabWrapper>
+  );
+};
+
+const TabWrapper = styled.div`
+  display: flex;
+  border-bottom: 4px solid ${({ theme }) => theme.palette.gray100};
+`;
+
+const TabButton = styled.button<{ isActive: boolean }>`
+  position: relative;
+  background: none;
+  border: none;
+  padding: 12px 16px;
+  margin-bottom: -1px;
+  cursor: pointer;
+
+  ${({ theme }) => theme.typo.body1m};
+  color: ${({ isActive, theme }) =>
+    isActive ? theme.palette.yellow700 : theme.palette.gray400};
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: ${({ isActive }) => (isActive ? '100%' : '0')};
+    height: 4px;
+    background-color: ${({ theme }) => theme.palette.yellow500};
+    transition: width 0.2s ease;
+  }
+`;

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -9,3 +9,4 @@ export { ButtonTextField } from './TextField/ButtonTextField';
 export { LoginButton } from './Button/LoginButton';
 export { Dropdown } from './Dropdown/Dropdown';
 export { Toggle } from './Toggle/Toggle';
+export { SessionCard } from './Card/SessionCard';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -11,3 +11,4 @@ export { Dropdown } from './Dropdown/Dropdown';
 export { Toggle } from './Toggle/Toggle';
 export { SessionCard } from './Card/SessionCard';
 export { RoomCard } from './Card/RoomCard';
+export { Tab } from './Tab/Tab';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -12,3 +12,4 @@ export { Toggle } from './Toggle/Toggle';
 export { SessionCard } from './Card/SessionCard';
 export { RoomCard } from './Card/RoomCard';
 export { Tab } from './Tab/Tab';
+export { ChatCard } from './Chat/ChatCard';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -10,3 +10,4 @@ export { LoginButton } from './Button/LoginButton';
 export { Dropdown } from './Dropdown/Dropdown';
 export { Toggle } from './Toggle/Toggle';
 export { SessionCard } from './Card/SessionCard';
+export { RoomCard } from './Card/RoomCard';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         version: 8.18.0
       awaitqueue:
         specifier: ^3.2.0
-        version: 3.2.0
+        version: 3.2.0(supports-color@9.4.0)
       axios:
         specifier: ^1.7.9
         version: 1.7.9(debug@4.4.0)
@@ -131,7 +131,7 @@ importers:
         version: 1.0.2
       debug:
         specifier: ^4.4.0
-        version: 4.4.0(supports-color@10.0.0)
+        version: 4.4.0(supports-color@9.4.0)
       ejs:
         specifier: ^3.1.10
         version: 3.1.10
@@ -146,7 +146,7 @@ importers:
         version: 4.21.2
       h264-profile-level-id:
         specifier: ^2.2.0
-        version: 2.2.0(supports-color@10.0.0)
+        version: 2.2.0
       hoist-non-react-statics:
         specifier: 3.3.2
         version: 3.3.2
@@ -372,6 +372,12 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.13.5)(typescript@5.7.3)
+      tsc-alias:
+        specifier: ^1.8.16
+        version: 1.8.16
+      tsconfig-paths:
+        specifier: ^3.12.0
+        version: 3.15.0
 
   apps/web:
     dependencies:
@@ -2465,6 +2471,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
 
@@ -2592,6 +2602,10 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2747,6 +2761,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4030,6 +4048,10 @@ packages:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
 
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
@@ -4599,6 +4621,10 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  mylas@2.1.13:
+    resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
+    engines: {node: '>=12.0.0'}
+
   nan@2.22.1:
     resolution: {integrity: sha512-pfRR4ZcNTSm2ZFHaztuvbICf+hyiG6ecA06SfAxoPmuHjvMu0KUIae7Y8GyVkbBqeEIidsmXeYooWIX9+qjfRQ==}
 
@@ -4712,6 +4738,10 @@ packages:
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
@@ -4996,6 +5026,10 @@ packages:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
 
+  plimit-lit@1.6.1:
+    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
+    engines: {node: '>=12'}
+
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
@@ -5101,6 +5135,10 @@ packages:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
 
+  queue-lit@1.5.2:
+    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
+    engines: {node: '>=12'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -5200,6 +5238,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -5821,6 +5863,11 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tsc-alias@1.8.16:
+    resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
+    engines: {node: '>=16.20.2'}
+    hasBin: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -6394,7 +6441,7 @@ snapshots:
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6446,7 +6493,7 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -7049,7 +7096,7 @@ snapshots:
       '@babel/parser': 7.26.9
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7071,7 +7118,7 @@ snapshots:
       '@electron/get': 3.1.0
       chalk: 4.1.2
       commander: 11.1.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 10.1.0
       listr2: 7.0.2
       semver: 7.7.1
@@ -7086,7 +7133,7 @@ snapshots:
       '@electron/rebuild': 3.7.1
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       find-up: 5.0.0
       fs-extra: 10.1.0
       log-symbols: 4.1.0
@@ -7113,7 +7160,7 @@ snapshots:
       '@electron/rebuild': 3.7.1
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fast-glob: 3.3.3
       filenamify: 4.3.0
       find-up: 5.0.0
@@ -7217,7 +7264,7 @@ snapshots:
       '@electron-forge/shared-types': 7.7.0
       '@electron-forge/web-multi-logger': 7.7.0
       chalk: 4.1.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 10.1.0
       listr2: 7.0.2
     transitivePeerDependencies:
@@ -7248,7 +7295,7 @@ snapshots:
       '@electron-forge/core-utils': 7.7.0
       '@electron-forge/shared-types': 7.7.0
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 10.1.0
       username: 5.1.0
     transitivePeerDependencies:
@@ -7321,7 +7368,7 @@ snapshots:
 
   '@electron/get@2.0.3':
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -7335,7 +7382,7 @@ snapshots:
 
   '@electron/get@3.1.0':
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -7365,7 +7412,7 @@ snapshots:
 
   '@electron/notarize@2.5.0':
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
@@ -7374,7 +7421,7 @@ snapshots:
   '@electron/osx-sign@1.3.2':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -7390,7 +7437,7 @@ snapshots:
       '@electron/osx-sign': 1.3.2
       '@electron/universal': 2.0.1
       '@electron/windows-sign': 1.2.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       extract-zip: 2.0.1
       filenamify: 4.3.0
       fs-extra: 11.3.0
@@ -7411,7 +7458,7 @@ snapshots:
       '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       detect-libc: 2.0.3
       fs-extra: 10.1.0
       got: 11.8.6
@@ -7430,7 +7477,7 @@ snapshots:
     dependencies:
       '@electron/asar': 3.3.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       dir-compare: 4.2.0
       fs-extra: 11.3.0
       minimatch: 9.0.5
@@ -7441,7 +7488,7 @@ snapshots:
   '@electron/windows-sign@1.2.1':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 11.3.0
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
@@ -7716,7 +7763,7 @@ snapshots:
   '@eslint/config-array@0.19.2':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7728,7 +7775,7 @@ snapshots:
   '@eslint/eslintrc@3.3.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -8378,7 +8425,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@9.21.0)(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@9.21.0)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.21.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -8412,7 +8459,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.21.0
     optionalDependencies:
       typescript: 5.7.3
@@ -8425,7 +8472,7 @@ snapshots:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.21.0
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -8445,7 +8492,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@9.21.0)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.21.0
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
@@ -8457,7 +8504,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       '@typescript-eslint/utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.21.0
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
@@ -8472,7 +8519,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
@@ -8486,7 +8533,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/visitor-keys': 8.24.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8577,7 +8624,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8624,6 +8671,11 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
 
   aproba@2.0.0: {}
 
@@ -8736,12 +8788,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  awaitqueue@3.2.0:
-    dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
-    transitivePeerDependencies:
-      - supports-color
-
   awaitqueue@3.2.0(supports-color@9.4.0):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
@@ -8797,6 +8843,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  binary-extensions@2.3.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -9045,6 +9093,18 @@ snapshots:
       upper-case-first: 1.1.2
 
   chardet@0.7.0: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   chownr@2.0.0: {}
 
@@ -9443,7 +9503,7 @@ snapshots:
     dependencies:
       '@electron/asar': 3.3.1
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       lodash: 4.17.21
@@ -9459,7 +9519,7 @@ snapshots:
   electron-installer-debian@3.2.0:
     dependencies:
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       electron-installer-common: 0.10.4
       fs-extra: 9.1.0
       get-folder-size: 2.0.1
@@ -9473,7 +9533,7 @@ snapshots:
   electron-installer-redhat@3.4.0:
     dependencies:
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       electron-installer-common: 0.10.4
       fs-extra: 9.1.0
       lodash: 4.17.21
@@ -9487,7 +9547,7 @@ snapshots:
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       detect-libc: 2.0.3
       fs-extra: 10.1.0
       got: 11.8.6
@@ -9514,7 +9574,7 @@ snapshots:
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.3.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 7.0.1
       lodash: 4.17.21
       temp: 0.9.4
@@ -9900,7 +9960,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -10047,7 +10107,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -10163,14 +10223,14 @@ snapshots:
 
   flora-colossus@2.0.0:
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - supports-color
 
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
 
   for-each@0.3.5:
     dependencies:
@@ -10256,7 +10316,7 @@ snapshots:
 
   galactus@1.0.0:
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       flora-colossus: 2.0.0
       fs-extra: 10.1.0
     transitivePeerDependencies:
@@ -10341,7 +10401,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10457,6 +10517,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  h264-profile-level-id@2.2.0:
+    dependencies:
+      debug: 4.4.0(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
   h264-profile-level-id@2.2.0(supports-color@10.0.0):
     dependencies:
       debug: 4.4.0(supports-color@10.0.0)
@@ -10541,14 +10607,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10562,14 +10628,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10695,6 +10761,10 @@ snapshots:
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.1.0
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
 
   is-boolean-object@1.2.2:
     dependencies:
@@ -10962,7 +11032,7 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       commander: 13.1.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       execa: 8.0.1
       lilconfig: 3.1.3
       listr2: 8.2.5
@@ -11296,6 +11366,8 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
+  mylas@2.1.13: {}
+
   nan@2.22.1: {}
 
   nanoid@3.3.8: {}
@@ -11449,6 +11521,8 @@ snapshots:
       resolve: 1.22.10
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
+
+  normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
 
@@ -11624,7 +11698,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -11758,6 +11832,10 @@ snapshots:
     dependencies:
       find-up: 5.0.0
 
+  plimit-lit@1.6.1:
+    dependencies:
+      queue-lit: 1.5.2
+
   plist@3.1.0:
     dependencies:
       '@xmldom/xmldom': 0.8.10
@@ -11824,7 +11902,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -11859,6 +11937,8 @@ snapshots:
       side-channel: 1.1.0
 
   querystring-es3@0.2.1: {}
+
+  queue-lit@1.5.2: {}
 
   queue-microtask@1.2.3: {}
 
@@ -11940,7 +12020,7 @@ snapshots:
 
   read-binary-file-arch@1.0.6:
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11970,6 +12050,10 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
 
   rechoir@0.8.0:
     dependencies:
@@ -12370,7 +12454,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -12378,7 +12462,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -12548,7 +12632,7 @@ snapshots:
 
   sumchecker@3.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12726,6 +12810,16 @@ snapshots:
       typescript: 5.7.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tsc-alias@1.8.16:
+    dependencies:
+      chokidar: 3.6.0
+      commander: 9.5.0
+      get-tsconfig: 4.10.0
+      globby: 11.1.0
+      mylas: 2.1.13
+      normalize-path: 3.0.0
+      plimit-lit: 1.6.1
 
   tsconfig-paths@3.15.0:
     dependencies:


### PR DESCRIPTION
## 🪐 작업 내용
컴포넌트 추가적으로 4개 만들었어요
webrtc 연결 방단위로 연결가능하도록 수정했어요

## 🛰️ 바뀐 내용

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 새로운 UI 컴포넌트(SessionCard, RoomCard, ChatCard, Tab) 추가 및 웹 테스트 페이지에 적용
  - 채팅 카드, 세션 카드, 룸 카드, 탭(탭 전환) 컴포넌트 도입
  - 세션 검색/찜 리스트 탭 UI 구현

- **Improvements**
  - 서버 메시지 구조 및 WebRTC 관련 로직을 방(room) 단위로 리팩터링하여 확장성 및 안정성 향상
  - 서버 타입, 메시지, 매니저 구조 개선 및 roomId 기반 처리로 변경

- **Chores**
  - .idea 폴더 gitignore에 추가
  - GitHub Actions를 통한 EC2 배포 워크플로우 추가

- **Bug Fixes**
  - Chip 컴포넌트 높이 조정(42px → 38px)

- **Documentation**
  - UI 컴포넌트 및 서버 매니저 관련 타입/인터페이스 공개 및 내보내기 추가

- **Refactor**
  - 서버 매니저(피어, 프로듀서, 트랜스포트) 및 메시지 타입 구조를 클래스 기반 및 room 단위로 개편
  - 패키지 의존성(tsc-alias, tsconfig-paths) 및 빌드 스크립트 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->