### PR TITLE
[FEAT] 합주방 방나가기 구현

### DIFF
--- a/apps/server/src/handlers/handleDisconnect.ts
+++ b/apps/server/src/handlers/handleDisconnect.ts
@@ -13,4 +13,7 @@ export function handleDisconnect(ws: ExtendedWebSocket) {
   room.transportManager.delete(ws.userId);
   room.peerManager.remove(ws.userId);
   room.producerManager.delete(ws.userId);
+
+  const summary = room.peerManager.getAllSummaries();
+  room.peerManager.broadcast('peerList', summary);
 }

--- a/apps/server/src/handlers/handleMessage.ts
+++ b/apps/server/src/handlers/handleMessage.ts
@@ -3,6 +3,7 @@ import { handleConnectTransport } from '@server/handlers/handleConnectTransport'
 import { handleConsume } from '@server/handlers/handleConsume';
 import { handleCreateRecvTransport } from '@server/handlers/handleCreateRecvTransport';
 import { handleCreateTransport } from '@server/handlers/handleCreateTransport';
+import { handleDisconnect } from '@server/handlers/handleDisconnect';
 import { handleGetRouterRtpCapabilities } from '@server/handlers/handleGetRouterRtpCapabilities';
 import { handleJoin } from '@server/handlers/handleJoin';
 import { handleProduce } from '@server/handlers/handleProduce';
@@ -27,5 +28,7 @@ export async function handleMessage(ws: WsSocket, data: Message) {
       return handleConnectRecvTransport(ws, data.dtlsParameters);
     case 'consume':
       return handleConsume(ws, data);
+    case 'disconnect':
+      return handleDisconnect(ws);
   }
 }

--- a/apps/server/src/types/messages.ts
+++ b/apps/server/src/types/messages.ts
@@ -34,4 +34,5 @@ export type Message =
   | {
       type: 'consume';
       rtpCapabilities: RtpCapabilities;
-    };
+    }
+  | { type: 'disconnect'; userId: string };

--- a/apps/web/src/components/CreateRoomPage/CreateRoomForm.tsx
+++ b/apps/web/src/components/CreateRoomPage/CreateRoomForm.tsx
@@ -25,7 +25,7 @@ export const CreateRoomForm = () => {
 
   return (
     <>
-      <CreateRooomContainer>
+      <CreateRoomContainer>
         <RoomBasicInfoSection
           roomName={form.name}
           setRoomName={(val) => updateField('name', val)}
@@ -58,12 +58,12 @@ export const CreateRoomForm = () => {
         >
           합주실 생성하기
         </Button>
-      </CreateRooomContainer>
+      </CreateRoomContainer>
     </>
   );
 };
 
-const CreateRooomContainer = styled.div`
+const CreateRoomContainer = styled.div`
   display: flex;
   padding: 60px;
   flex-direction: column;

--- a/apps/web/src/components/CreateRoomPage/RoomBasicInfoSection.tsx
+++ b/apps/web/src/components/CreateRoomPage/RoomBasicInfoSection.tsx
@@ -92,6 +92,7 @@ export const RoomBasicInfoSection = ({
           width="100%"
           onChange={(e) => setAudiencePW(e.target.value)}
           placeholder="관중 비밀번호"
+          disabled={!isAudienceLocking}
         />
       </AccessContainer>
 
@@ -108,6 +109,7 @@ export const RoomBasicInfoSection = ({
           width="100%"
           onChange={(e) => setPlayerPW(e.target.value)}
           placeholder="연주자 비밀번호"
+          disabled={!isPlayerLocking}
         />
       </AccessContainer>
     </>

--- a/apps/web/src/webrtc.ts
+++ b/apps/web/src/webrtc.ts
@@ -7,6 +7,7 @@ interface WebRTCOptions {
   onPeerList: (peers: { id: string; name: string; role: string }[]) => void;
   userInfo: { id: string; name: string; role: string };
   roomId: string;
+  onSocketInit?: (ws: WebSocket) => void;
 }
 
 export const startWebRTC = ({
@@ -16,11 +17,14 @@ export const startWebRTC = ({
   onPeerList,
   userInfo,
   roomId,
+  onSocketInit,
 }: WebRTCOptions) => {
   const socket = new WebSocket('ws://localhost:4000');
   let device: Device;
   let sendTransport: types.Transport;
   let recvTransport: types.Transport;
+
+  if (onSocketInit) onSocketInit(socket);
 
   socket.onopen = () => {
     onLog('WebSocket 연결됨');


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #56

## 🪐 작업 내용
SFU 서버 disconnect 구현함


## 🛰️ 바뀐 내용

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - WebRTC 연결 시 WebSocket 객체를 초기화 직후 외부에서 접근할 수 있는 콜백 옵션이 추가되었습니다.
  - 서버에서 클라이언트가 직접 'disconnect' 메시지를 전송할 수 있도록 지원합니다.

- **Bug Fixes**
  - 방 생성 폼의 컨테이너 컴포넌트 이름 오타를 수정했습니다.
  - 방 생성 시, 관전자/플레이어 잠금 토글이 꺼진 경우 해당 비밀번호 입력란이 비활성화됩니다.

- **기타 개선**
  - 사용자가 연결 해제 시, 모든 클라이언트에 최신 피어 목록이 즉시 반영되어 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->