### PR TITLE
[FEAT] 합주실 상세페이지 구현

### DIFF
--- a/apps/web/src/components/RoomDetailPage/RoomDetailView.tsx
+++ b/apps/web/src/components/RoomDetailPage/RoomDetailView.tsx
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+import { PlayRoomDetail } from '@web/models/playroomDetail';
+import { RoomInfo } from './RoomInfo';
+import { Button } from '@repo/ui';
+
+type Props = {
+  data: PlayRoomDetail;
+};
+
+export const RoomDetailView = ({ data }: Props) => {
+  const { name, description, genreList, sessionInfoList, imageUrl } = data;
+
+  return (
+    <DetailPageContainer>
+      <Image src={imageUrl} alt="룸 이미지" />
+      <InfoSection>
+        <RoomInfo label="룸 이름:">{name}</RoomInfo>
+        <RoomInfo label="룸 설명:">{description}</RoomInfo>
+        <RoomInfo label="장르:">{genreList.join(', ')}</RoomInfo>
+        <RoomInfo label="세션:">
+          {sessionInfoList.map((s) => `${s.sessionName}`).join(', ')}
+        </RoomInfo>
+
+        <ButtonGroup>
+          <Button colorTheme="yellow1" width="280px" height="48px">
+            관중 입장하기
+          </Button>
+          <Button colorTheme="yellow2" width="280px" height="48px">
+            연주자 입장하기
+          </Button>
+        </ButtonGroup>
+      </InfoSection>
+    </DetailPageContainer>
+  );
+};
+
+const DetailPageContainer = styled.div`
+  display: flex;
+  padding: 120px;
+  justify-content: center;
+  gap: 32px;
+`;
+
+const Image = styled.img`
+  width: 270px;
+  object-fit: cover;
+  border-radius: 16px;
+`;
+
+const InfoSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: 32px;
+`;

--- a/apps/web/src/components/RoomDetailPage/RoomInfo.tsx
+++ b/apps/web/src/components/RoomDetailPage/RoomInfo.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+
+export const RoomInfo = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <Row>
+    <Label>{label}</Label>
+    <Value> {children}</Value>
+  </Row>
+);
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  align-items: center;
+`;
+
+const Label = styled.div`
+  ${({ theme }) => theme.typo.body1m};
+  color: ${({ theme }) => theme.palette.yellow800};
+`;
+
+const Value = styled.div`
+  ${({ theme }) => theme.typo.body1m};
+  color: ${({ theme }) => theme.palette.gray800};
+`;

--- a/apps/web/src/components/SearchRoomPage/SavedRoomList.tsx
+++ b/apps/web/src/components/SearchRoomPage/SavedRoomList.tsx
@@ -1,10 +1,12 @@
 import { RoomCard } from '@repo/ui';
 import { useLikedRooms } from '@web/hooks/SearchRoom/useLikedRooms';
 import { useToggleLike } from '@web/hooks/SearchRoom/useToggleLike';
+import { useNavigate } from 'react-router-dom';
 
 export const SavedRoomList = () => {
   const { roomList, removeRoomFromList } = useLikedRooms();
   const { toggleLike } = useToggleLike();
+  const navigate = useNavigate();
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
       {roomList.map((room) => (
@@ -15,6 +17,7 @@ export const SavedRoomList = () => {
           genre={room.genre}
           remainSessions={room.remainSessions}
           isLiked={room.isLiked}
+          onClick={() => navigate(`/room/${room.playRoomId}`)}
           onLike={() =>
             toggleLike(room.playRoomId, room.isLiked, () => {
               removeRoomFromList(room.playRoomId);

--- a/apps/web/src/components/SearchRoomPage/SearchRoomForm.tsx
+++ b/apps/web/src/components/SearchRoomPage/SearchRoomForm.tsx
@@ -4,6 +4,7 @@ import { GENRES, SESSION_LABELS } from '@web/constants/onboarding';
 import { useState } from 'react';
 import { useRoomSearch } from '@web/hooks/SearchRoom/useRoomSearch';
 import { useToggleLike } from '@web/hooks/SearchRoom/useToggleLike';
+import { useNavigate } from 'react-router-dom';
 
 const LOCK_OPTIONS = [
   { label: '잠금', value: 'locked' },
@@ -31,7 +32,7 @@ export const SearchRoomForm = () => {
   } = useRoomSearch({ isPlayerLocked: toBoolean(isLockedList) });
 
   const { toggleLike } = useToggleLike();
-  console.log('roomList', roomList);
+  const navigate = useNavigate();
 
   return (
     <>
@@ -77,6 +78,7 @@ export const SearchRoomForm = () => {
             genre={room.genre}
             remainSessions={room.remainSessions}
             isLiked={room.isLiked}
+            onClick={() => navigate(`/room/${room.playRoomId}`)}
             onLike={() =>
               toggleLike(room.playRoomId, room.isLiked, () => {
                 handleSearch();

--- a/apps/web/src/components/common/RoomFooter.tsx
+++ b/apps/web/src/components/common/RoomFooter.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+
+interface RoomFooterProps {
+  onLeave: () => void;
+}
+
+export const RoomFooter = ({ onLeave }: RoomFooterProps) => (
+  <FooterContainer>
+    <BottomZone>
+      <LeaveButton onClick={onLeave}>방 나가기</LeaveButton>
+    </BottomZone>
+  </FooterContainer>
+);
+
+const FooterContainer = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+`;
+
+const BottomZone = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding: 20px 42px;
+  border-top: 1px solid ${({ theme }) => theme.palette.yellow100};
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(5px);
+`;
+
+const LeaveButton = styled.button`
+  padding: 8px 24px;
+  border-radius: 8px;
+
+  ${({ theme }) => theme.typo.body2m};
+
+  color: ${({ theme }) => theme.palette.white};
+  background: ${({ theme }) => theme.palette.yellow600};
+
+  &:hover {
+    background: ${({ theme }) => theme.palette.yellow700};
+  }
+`;

--- a/apps/web/src/models/playroomDetail.ts
+++ b/apps/web/src/models/playroomDetail.ts
@@ -1,0 +1,17 @@
+export type PlayRoomDetail = {
+  name: string;
+  description: string;
+  isPlayerLocked: boolean;
+  isAudienceLocked: boolean;
+  genreList: string[];
+  sessionInfoList: {
+    sessionName: string;
+    max: number;
+    count: number;
+  }[];
+  imageUrl: string;
+  scheduleList: {
+    id: number;
+    date: string;
+  }[];
+};

--- a/apps/web/src/pages/RoomDetailPage.tsx
+++ b/apps/web/src/pages/RoomDetailPage.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getPlayRoomDetail } from '@web/services/getPlayRoomDetail';
+import { PlayRoomDetail } from '@web/models/playroomDetail';
+
+import { Header } from '@web/components/common/Header';
+import { RoomDetailView } from '@web/components/RoomDetailPage/RoomDetailView';
+
+export const RoomDetailPage = () => {
+  const { roomId } = useParams();
+  const [data, setData] = useState<PlayRoomDetail | null>(null);
+
+  useEffect(() => {
+    if (!roomId) return;
+
+    getPlayRoomDetail(roomId).then((res) => {
+      const patched: PlayRoomDetail = {
+        ...res,
+        sessionInfoList: res.sessionInfoList.map((s) => ({
+          sessionName: s.sessionName,
+          max: s.max,
+          count: s.count,
+        })),
+      };
+      setData(patched);
+    });
+  }, [roomId]);
+
+  if (!data) return <div>불러오는 중...</div>;
+
+  return (
+    <>
+      <Header />
+      <RoomDetailView data={data} />
+    </>
+  );
+};

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -8,6 +8,7 @@ import { HomePage } from '@web/pages/HomePage';
 import { SessionPage } from '@web/pages/SessionPage';
 import { SearchRoomPage } from '@web/pages/SearchRoomPage';
 import { CreateRoomPage } from '@web/pages/CreateRoomPage';
+import { RoomDetailPage } from '@web/pages/RoomDetailPage';
 
 export const Router = () => {
   return (
@@ -21,6 +22,7 @@ export const Router = () => {
         <Route path="/session" element={<SessionPage />} />
         <Route path="/search-room" element={<SearchRoomPage />} />
         <Route path="/create-room" element={<CreateRoomPage />} />
+        <Route path="/room/:roomId" element={<RoomDetailPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/web/src/services/getPlayRoomDetail.ts
+++ b/apps/web/src/services/getPlayRoomDetail.ts
@@ -1,0 +1,10 @@
+import { fetcher } from '@repo/api';
+import { PlayRoomDetail } from '@web/models/playroomDetail';
+
+export const getPlayRoomDetail = async (playRoomId: string) => {
+  const res = await fetcher.get<PlayRoomDetail>(
+    `/play-room/${playRoomId}/detailInfo`
+  );
+
+  return res;
+};

--- a/packages/ui/src/components/Card/ParticipantCard.tsx
+++ b/packages/ui/src/components/Card/ParticipantCard.tsx
@@ -1,0 +1,137 @@
+import styled from '@emotion/styled';
+import { useTheme } from '@emotion/react';
+import { Chip } from '../Chip/Chip';
+import { useState } from 'react';
+
+type ParticipantCardProps = {
+  profileImageUrl?: string;
+  name: string;
+  role: string;
+  gainNode?: GainNode;
+  isMe?: boolean;
+};
+
+export const ParticipantCard = ({
+  profileImageUrl,
+  name,
+  role,
+  gainNode,
+  isMe,
+}: ParticipantCardProps) => {
+  const theme = useTheme();
+  const [gain, setGain] = useState(50);
+
+  const handleGainChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseFloat(e.target.value);
+    setGain(value);
+    if (gainNode) gainNode.gain.value = value;
+  };
+
+  return (
+    <CardContainer highlight={isMe}>
+      <ImageContainer>
+        {profileImageUrl ? (
+          <ProfileImage src={profileImageUrl} alt="profile" />
+        ) : (
+          <PlaceholderImage />
+        )}
+        <TagList>
+          <Chip colorTheme="yellow">{role}</Chip>
+        </TagList>
+      </ImageContainer>
+      <InfoArea>
+        <Name>{name}</Name>
+        {gainNode && (
+          <VolumeSlider
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={gain}
+            onChange={handleGainChange}
+            filledRatio={gain / 100}
+          />
+        )}
+      </InfoArea>
+    </CardContainer>
+  );
+};
+
+const CardContainer = styled.div<{ highlight?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  width: 273px;
+  padding: 12px;
+  border-radius: 12px;
+  background-color: ${({ highlight }) => (highlight ? '#fff9d6' : 'white')};
+  box-shadow: 0 0 0 1px ${({ theme }) => theme.palette.gray200};
+`;
+
+const ImageContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 120px;
+  background-color: ${({ theme }) => theme.palette.gray100};
+  border-radius: 10px;
+  overflow: hidden;
+`;
+
+const ProfileImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const PlaceholderImage = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: gray;
+`;
+
+const TagList = styled.div`
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  display: flex;
+  gap: 6px;
+`;
+
+const InfoArea = styled.div`
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const Name = styled.div`
+  ${({ theme }) => theme.typo.body1m};
+  color: ${({ theme }) => theme.palette.yellow800};
+  margin-bottom: 4px;
+`;
+
+const VolumeSlider = styled.input<{ filledRatio: number }>`
+  width: 100%;
+  height: 8px;
+  border-radius: 5px;
+  outline: none;
+  -webkit-appearance: none;
+
+  background: ${({ theme, filledRatio }) =>
+    `linear-gradient(to right, ${theme.palette.yellow500} ${filledRatio * 100}%, ${theme.palette.gray300} ${filledRatio * 100}%)`};
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.palette.yellow500};
+    cursor: pointer;
+    margin-top: -3px;
+  }
+
+  &::-webkit-slider-runnable-track {
+    height: 8px;
+    border-radius: 5px;
+    background: transparent;
+  }
+`;

--- a/packages/ui/src/components/Card/RoomCard.tsx
+++ b/packages/ui/src/components/Card/RoomCard.tsx
@@ -10,6 +10,7 @@ export type RoomCardProps = React.ComponentProps<'div'> & {
   name: string;
   isLiked: boolean;
   onLike: () => void;
+  onClick?: () => void;
 };
 
 export const RoomCard = ({
@@ -19,11 +20,12 @@ export const RoomCard = ({
   name,
   isLiked,
   onLike,
+  onClick,
 }: RoomCardProps) => {
   const theme = useTheme();
 
   return (
-    <CardContainer>
+  <CardContainer onClick={onClick}>
       <ImageContainer imgUrl={imgUrl}>
         <LikeButton onClick={onLike}>
           <Icon

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -13,3 +13,4 @@ export { SessionCard } from './Card/SessionCard';
 export { RoomCard } from './Card/RoomCard';
 export { Tab } from './Tab/Tab';
 export { ChatCard } from './Chat/ChatCard';
+export { ParticipantCard } from './Card/ParticipantCard';


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #60 

## 🪐 작업 내용
캘린더 기능 제외입니다

## 🛰️ 바뀐 내용

## 📚 Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 방 상세 페이지가 추가되어 각 방의 상세 정보를 확인할 수 있습니다.
    - 방 상세 페이지에서 방 이름, 설명, 장르, 세션 정보, 이미지 등을 확인할 수 있습니다.
    - 방 카드 클릭 시 해당 방의 상세 페이지로 이동할 수 있습니다.
    - 방 상세 하단에 “방 나가기” 고정 푸터 버튼이 추가되었습니다.
    - 참가자 정보를 보여주는 ParticipantCard 컴포넌트가 추가되었습니다.
- **개선 사항**
    - RoomCard에 클릭 이벤트가 추가되어 카드 전체를 클릭하여 상세 페이지로 이동할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->