### PR TITLE
Add Vitest and tests for userId utility

### DIFF
--- a/apps/web/src/utils/__tests__/userInfo.test.ts
+++ b/apps/web/src/utils/__tests__/userInfo.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getOrCreateUserId } from '../userInfo';
+
+describe('getOrCreateUserId', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('returns stored userId when present', () => {
+    localStorage.setItem('userId', 'stored-id');
+    const id = getOrCreateUserId();
+    expect(id).toBe('stored-id');
+  });
+
+  it('generates and stores new userId when not present', () => {
+    const spy = vi
+      .spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValue('new-id');
+    const id = getOrCreateUserId();
+    expect(spy).toHaveBeenCalled();
+    expect(id).toBe('new-id');
+    expect(localStorage.getItem('userId')).toBe('new-id');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "test": "vitest"
   },
   "devDependencies": {
     "@emotion/react": "^11.14.0",
@@ -18,7 +19,8 @@
     "prettier": "^3.3.3",
     "tsx": "^4.19.3",
     "turbo": "^2.3.3",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "^1.5.3"
   },
   "packageManager": "pnpm@9.0.0",
   "engines": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['**/__tests__/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- set up Vitest with jsdom
- add a test suite for `getOrCreateUserId`
- expose `pnpm test` script

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68419bd267c883249fa64498b1036bca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - 기존 유틸리티 함수에 대한 단위 테스트가 추가되었습니다.
  - Vitest 테스트 러너가 도입되어 테스트 실행이 가능해졌습니다.

- **Chores**
  - 테스트 환경 구성을 위한 설정 파일이 추가되었습니다.
  - 테스트 실행을 위한 스크립트와 개발용 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->